### PR TITLE
Don't start mako explicitly

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -44,4 +44,3 @@ client.unfocused #00a489 #173f4f #35b9ab
 client.focused_inactive #6da741 #00a489 #173f4f
 
 exec "systemctl --user import-environment; systemctl --user start sway-session.target"
-exec mako


### PR DESCRIPTION
mako is started when needed via D-BUS activation. Not starting it
explicitly can improve Sway's startup time.

See https://github.com/emersion/mako/blob/237f6eabdd3e428cefc852a53306d34ef481c8a5/README.md#running

Related discussion: https://github.com/openSUSE/openSUSEway/issues/3#issuecomment-649524397