### PR TITLE
moving enviroments to run script, adding greetd config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For this config please install these packages:
 sudo zypper in openSUSEway
 ```
 
-openSUSEway imports some recomended (optional) variables from `/etc/sway/env`, that is done by `/etc/profile.d/openSUSEway.sh` for text mode and by `/usr/lib/environment.d/50-openSUSE.conf` for systemd graphic environments.
+openSUSEway imports some recomended (optional) variables from `/etc/sway/env`, that is done by `sway/sway-run.sh` for text mode and by `sway/sway.service` for systemd graphic environments.
 
 [openSUSEway desktop enviroment](https://en.opensuse.org/Portal:OpenSUSEway) for more details on complete desktop enviroment for openSUSE.
 

--- a/greetd/config.toml
+++ b/greetd/config.toml
@@ -1,0 +1,17 @@
+[terminal]
+# The VT to run the greeter on. Can be "next", "current" or a number
+# designating the VT.
+vt = 1
+
+# The default session, also known as the greeter.
+[default_session]
+
+# `agreety` is the bundled agetty/login-lookalike. You can replace `$SHELL`
+# with whatever you want started, such as `sway`.
+#
+command = "sway --config /etc/greetd/sway-config"
+
+# The user to run the command as. The privileges this user must have depends
+# on the greeter. A graphical greeter may for example require the user to be
+# in the `video` group.
+user = "greeter"

--- a/greetd/environments
+++ b/greetd/environments
@@ -1,0 +1,2 @@
+sway-run.sh
+bash

--- a/greetd/sway-config
+++ b/greetd/sway-config
@@ -1,0 +1,9 @@
+exec "gtkgreet -l; swaymsg exit"
+
+bindsym Mod4+shift+e exec swaynag \
+	-t warning \
+	-m 'What do you want to do?' \
+	-b 'Poweroff' 'systemctl poweroff' \
+	-b 'Reboot' 'systemctl reboot'
+
+#include /etc/sway/config.d/

--- a/openSUSEway.sh
+++ b/openSUSEway.sh
@@ -1,5 +1,0 @@
-# this file imports openSUSEway desktop enviroments
-# should end up im /etc/profile.d/
-set -a
-. /etc/sway/env
-set +a

--- a/sway/sway-run.sh
+++ b/sway/sway-run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Session
+export XDG_SESSION_TYPE=wayland
+export XDG_SESSION_DESKTOP=sway
+export XDG_CURRENT_DESKTOP=sway
+
+# this file imports openSUSEway desktop enviroments
+set -a
+. /etc/sway/env
+set +a
+
+systemd-cat --identifier=sway sway $@
+

--- a/sway/sway-session.target
+++ b/sway/sway-session.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=sway session
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target

--- a/sway/sway.desktop
+++ b/sway/sway.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Sway
+Comment=An i3-compatible Wayland compositor
+Exec=sway-run.sh
+Type=Application

--- a/sway/sway.service
+++ b/sway/sway.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=sway - SirCmpwn's Wayland window manager
+Documentation=man:sway(5)
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sway/env
+ExecStart=sway
+Restart=on-failure
+RestartSec=1
+TimeoutStopSec=10


### PR DESCRIPTION
This fixes #28 and fixes #27 .

Don't force environment, instead add it to the wrapper script.
Add greetd config files to install it later with openSUSEway pattern and package.