### PR TITLE
Use late evaluation of $term variable for bindsym $mod+Return

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -64,7 +64,7 @@ output * bg /usr/share/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 # Basics:
 #
     # Start a terminal
-    bindsym $mod+Return exec $term
+    bindsym $mod+Return exec $$term
 
     # Kill focused window
     bindsym $mod+Shift+q kill


### PR DESCRIPTION
So that an user can set different terminal application (or use different options for alacritty).