### PR TITLE
GDM messes up tty1

### DIFF
--- a/greetd/config.toml
+++ b/greetd/config.toml
@@ -1,7 +1,7 @@
 [terminal]
 # The VT to run the greeter on. Can be "next", "current" or a number
 # designating the VT.
-vt = 1
+vt = next
 
 # The default session, also known as the greeter.
 [default_session]

--- a/greetd/sway-config
+++ b/greetd/sway-config
@@ -6,4 +6,6 @@ bindsym Mod4+shift+e exec swaynag \
 	-b 'Poweroff' 'systemctl poweroff' \
 	-b 'Reboot' 'systemctl reboot'
 
+exec /usr/libexec/polkit-gnome-authentication-agent-1
+
 #include /etc/sway/config.d/


### PR DESCRIPTION
in case GDM is installed it creates `/usr/lib/systemd/logind.conf.d/reserveVT.conf` with `ReserveVT=1` which makes it unavailable for greeter.
fixes #52