### PR TITLE
Use new option for window opacity

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -1,1 +1,2 @@
-background_opacity: 0.4
+window:
+  opacity: 0.4


### PR DESCRIPTION
Configuration option background_opacity is deprecated from version
0.10.0 and is replaced by window.opacity