### PR TITLE
Replace alacritty terminal to foot

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -1,2 +1,0 @@
-window:
-  opacity: 0.4

--- a/.config/foot/foot.ini
+++ b/.config/foot/foot.ini
@@ -1,0 +1,2 @@
+[colors]
+ alpha=0.4

--- a/.config/sway/config
+++ b/.config/sway/config
@@ -14,7 +14,7 @@ set $down j
 set $up k
 set $right l
 # Your preferred terminal emulator
-set $term alacritty --config-file /etc/alacritty/alacritty.yml
+set $term foot --config /etc/xdg/foot/foot-openSUSEway.ini
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.


### PR DESCRIPTION
Foot and alacritty share similar goals as they try to be a minimalistic terminal emulators only giving simpler features. But foot is very lightweight, both in dependencies and memory usage in comparison to alacritty. Both are great terminals and both are native on Wayland. 

Also other influences is because of this PR https://github.com/swaywm/sway/pull/6255#issue-875946597 