### PR TITLE
Add openSUSE wob theme

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -50,13 +50,15 @@ client.focused #6da741 #173f4f #73ba25
 client.unfocused #00a489 #173f4f #35b9ab
 client.focused_inactive #6da741 #00a489 #173f4f
 
+set $wob wob --timeout 1000 --height 32 --offset 0 --border 2 --padding 2 --border-color=#35B9AB66 --background-color=#173f4f66 --bar-color=#35b9abff --overflow-border-color=#ee2e2466 --overflow-background-color=#173f4f66 --overflow-bar-color=#ee2e24ff
+
 exec_always {
     systemctl --user import-environment
     gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
     gsettings set org.gnome.desktop.interface icon-theme 'Adwaita'
     gsettings set org.gnome.desktop.interface cursor-theme 'Adwaita'
     test -e $SWAYSOCK.wob || mkfifo $SWAYSOCK.wob
-    tail -f $SWAYSOCK.wob | wob
+    tail -f $SWAYSOCK.wob | $wob
 }
 
 exec /usr/libexec/polkit-gnome-authentication-agent-1


### PR DESCRIPTION
Add theme using wob command line options. Closes #47.

Upstream wob has moved to a .ini configuration file, but has not released the next version yet.
It will be easy to migrate this configuration to the wob.ini format once it is released.