### PR TITLE
Improve some defaults

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -9,6 +9,17 @@ set $menu wofi --show drun,run
 # openSUSE wallpaper
 output * bg /usr/share/wallpapers/default-1920x1080.jpg fill
 
+# Enable common options for generic touchpads
+input "type:touchpad" {
+  tap enabled
+  natural_scroll enabled
+  middle_emulation enabled
+}
+
+# Cycle through workspaces
+bindsym $mod+tab workspace next_on_output
+bindsym $mod+Shift+tab workspace prev_on_output
+
 # Idle configuration
 exec swayidle -w \
          timeout 300 'swaylock -f -c 000000' \

--- a/greetd/sway-config
+++ b/greetd/sway-config
@@ -1,3 +1,7 @@
+input "type:touchpad" {
+  tap enabled
+}
+
 exec "gtkgreet -l -s /etc/greetd/style.css; swaymsg exit"
 
 bindsym Mod4+shift+e exec swaynag \


### PR DESCRIPTION
Enable sensible touchpad behaviour by default, both in the sway session
and in greetd.
Cycle through workspaces with mod+tab, mod+shift+tab.

Address some suggestions from #69 