### PR TITLE
Import user configuration variables

### DIFF
--- a/sway/sway-run.sh
+++ b/sway/sway-run.sh
@@ -5,9 +5,11 @@ export XDG_SESSION_TYPE=wayland
 export XDG_SESSION_DESKTOP=sway
 export XDG_CURRENT_DESKTOP=sway
 
-# this file imports openSUSEway desktop enviroments
 set -a
+# Import openSUSEway environment variables
 . /etc/sway/env
+# Import user environment variables
+. ~/.config/environment.d/*.conf
 set +a
 
 systemd-cat --identifier=sway sway $@


### PR DESCRIPTION
GDM and KDE Plasma source systemd user environment variables from ~/.config/environment.d/, sway does not [0].
Let's provide this functionality while we're at it.

[0] https://wiki.archlinux.org/title/Environment_variables#Wayland_environment