### PR TITLE
Import all user configuration variables from environment.d

### DIFF
--- a/sway/sway-run.sh
+++ b/sway/sway-run.sh
@@ -8,9 +8,8 @@ export XDG_CURRENT_DESKTOP=sway
 set -a
 # Import openSUSEway environment variables
 . /etc/sway/env
-# Import user environment variables
-. ~/.config/environment.d/*.conf
+# Import environment.d variables by calling the systemd generator
+eval "$(/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)"
 set +a
 
 systemd-cat --identifier=sway sway $@
-


### PR DESCRIPTION
As mentioned in #77, I just realized this fix is needed to actually import all variables.