### PR TITLE
System mode menu

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -20,12 +20,14 @@ input "type:touchpad" {
 bindsym $mod+tab workspace next_on_output
 bindsym $mod+Shift+tab workspace prev_on_output
 
+# Lockscreen configuration
+set $screenlock 'swaylock -f -c 000000'
 # Idle configuration
 exec swayidle -w \
-         timeout 300 'swaylock -f -c 000000' \
+         timeout 300 $screenlock \
          timeout 600 'swaymsg "output * dpms off"' \
               resume 'swaymsg "output * dpms on"' \
-         before-sleep 'swaylock -f -c 000000'
+         before-sleep $screenlock
 
 bindsym --to-code {
     $mod+b splith

--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -56,6 +56,23 @@ bar {
     swaybar_command waybar
 }
 
+# System mode menu
+set $mode_system "What to do? (l) lock, (e) logout, (r) reboot, (s) suspend, (Shift+s) shutdown"
+mode $mode_system {
+	bindsym l exec $screenlock; mode "default"
+	bindsym e exec swaymsg exit; mode "default"
+	bindsym r exec systemctl reboot; mode "default"
+	bindsym s exec systemctl suspend; mode "default"
+	bindsym Shift+s exec systemctl poweroff; mode "default"
+
+	# back to normal: Enter or Escape
+	bindsym Return mode "default"
+	bindsym Escape mode "default"
+}
+unbindsym $mod+Shift+e
+bindsym $mod+Shift+e mode $mode_system
+
+
 # openSUSE theme
 default_border pixel 2
 gaps inner 10


### PR DESCRIPTION
Replace the stock `swaynag` session menu with a more complete and functional alternative.
I have been using this in my configuration pretty much since my i3 days in 2014.

This is what it looks like:
![20230116_09h19m24s_grim](https://user-images.githubusercontent.com/101266837/212630788-a4e41293-1e66-4e15-800c-f1f1877dc3b1.png)