### PR TITLE
Install sway systemd components to the correct directories

### DIFF
--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -150,8 +150,8 @@ install -D -p -m 644 .config/sway/config %{buildroot}%{_sysconfdir}/sway/config
 install -D -p -m 644 .config/sway/env %{buildroot}%{_sysconfdir}/sway/env
 install -D -p -m 644 .config/sway/config.d/50-openSUSE.conf %{buildroot}%{_sysconfdir}/sway/config.d/50-openSUSE.conf
 
-install -D -p -m 644 sway/sway-session.target %{buildroot}%{_unitdir}/sway-session.target
-install -D -p -m 644 sway/sway.service %{buildroot}%{_unitdir}/sway.service
+install -D -p -m 644 sway/sway-session.target %{buildroot}%{_prefix}/lib/systemd/user/sway-session.target
+install -D -p -m 644 sway/sway.service %{buildroot}%{_prefix}/lib/systemd/user/sway.service
 install -D -p -m 644 sway/sway.desktop %{buildroot}%{_datadir}/wayland-sessions/sway.desktop.brand
 install -D -p -m 755 sway/sway-run.sh %{buildroot}%{_bindir}/sway-run.sh
 
@@ -217,8 +217,8 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %config %{_sysconfdir}/sway/env
 %dir %{_sysconfdir}/sway/config.d
 %config %{_sysconfdir}/sway/config.d/50-openSUSE.conf
-%{_unitdir}/sway-session.target
-%{_unitdir}/sway.service
+%{_prefix}/lib/systemd/user/sway-session.target
+%{_prefix}/lib/systemd/user/sway.service
 %{_datadir}/wayland-sessions/sway.desktop.brand
 %{_bindir}/sway-run.sh
 


### PR DESCRIPTION
Both sway.service and sway-session.target are to be installed in the user systemd session.

Fix #95.