### PR TITLE
Package scratchpad-indicator helper

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -142,7 +142,7 @@
         "format-text": "{}",
         "return-type": "json",
         "interval": 3,
-        "exec": "scratchpad-indicator.sh 2> /dev/null",
+        "exec": "/usr/share/openSUSEway/helpers/scratchpad-indicator.sh 2> /dev/null",
         "exec-if": "exit 0",
         "on-click": "swaymsg 'scratchpad show'",
         "on-click-right": "swaymsg 'move scratchpad'"

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -168,6 +168,7 @@ sed -i -e "s|wofi --show.*|wofi --conf=%{_sysconfdir}/wofi/config --style=%{_sys
 ## waybar
 install -D -p -m 644 .config/waybar/config %{buildroot}%{_sysconfdir}/xdg/waybar/config
 install -D -p -m 644 .config/waybar/style.css %{buildroot}%{_sysconfdir}/xdg/waybar/style.css
+install -D -p -m 755 .config/waybar/scratchpad-indicator.sh %{buildroot}%{_datadir}/openSUSEway/helpers/scratchpad-indicator.sh
 
 ## wob
 install -D -p -m 644 .config/wob/wob.ini %{buildroot}%{_sysconfdir}/sway/wob/wob.ini
@@ -214,6 +215,8 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %attr(644,greeter,greeter) %config %{_sysconfdir}/greetd/config.toml.way
 %attr(644,greeter,greeter) %config %{_sysconfdir}/greetd/sway-config
 %attr(644,greeter,greeter) %config %{_sysconfdir}/greetd/environments
+%dir %{_datadir}/openSUSEway/
+%dir %{_datadir}/openSUSEway/helpers/
 
 %files -n patterns-openSUSEway
 %dir %{_defaultdocdir}/patterns
@@ -248,5 +251,6 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %dir %{_sysconfdir}/xdg/waybar
 %config(noreplace) %{_sysconfdir}/xdg/waybar/config
 %config(noreplace) %{_sysconfdir}/xdg/waybar/style.css
+%{_datadir}/openSUSEway/helpers/scratchpad-indicator.sh
 
 %changelog


### PR DESCRIPTION
Create a `/usr/share/openSUSEway/helpers` folder for helper scripts pertaining to openSUSEway. I foresee they will mostly be waybar helpers, but not only, so I left the name generic.

Fix #106.