### PR TITLE
Allow sway to be run with proprietary drivers

### DIFF
--- a/sway/sway-run.sh
+++ b/sway/sway-run.sh
@@ -12,7 +12,15 @@ set -a
 eval "$(/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)"
 set +a
 
+# Set dependencies to run with proprietary drivers
+if grep -qE "nvidia|fglrx" /proc/modules; then
+	export WLR_NO_HARDWARE_CURSORS=1
+	unsupported_gpu="--unsupported-gpu"
+else
+	unsupported_gpu=""
+fi
+
 # Start the Sway session
 systemctl --user start sway-session.target
 
-systemd-cat --identifier=sway sway $@
+systemd-cat --identifier=sway sway $unsupported_gpu $@


### PR DESCRIPTION
Based on https://forum.endeavouros.com/t/sway-with-nvidia-tutorial/23733, these have been the changes needed to make it work.