### PR TITLE
flutter takes color-scheme instead of theme

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -90,6 +90,7 @@ exec_always {
     gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
     gsettings set org.gnome.desktop.interface icon-theme 'Adwaita'
     gsettings set org.gnome.desktop.interface cursor-theme 'Adwaita'
+    gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
     test -e $SWAYSOCK.wob || mkfifo $SWAYSOCK.wob
     tail -f $SWAYSOCK.wob | $wob
     swaync --style /etc/sway/swaync/style.css --config /etc/sway/swaync/config.json


### PR DESCRIPTION
Setup fluffychat from flathub and found that it is in a light theme. This should fix it, as well as maybe help other applications.

  - https://gitlab.com/famedly/fluffychat/-/issues/1111#note_1324504258
  - https://wiki.archlinux.org/title/Dark_mode_switching#gsettings
