### PR TITLE
Add screenshot utility configuration

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -49,6 +49,24 @@ bindsym --no-warn XF86AudioPlay exec playerctl play-pause
 bindsym --no-warn XF86AudioNext exec playerctl next
 bindsym --no-warn XF86AudioPrev exec playerctl previous
 
+## Screenshots
+# Area selection shortcuts
+set $selected_window swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp
+set $focused_window swaymsg -t get_tree | jq -j '.. | select(.type?) | select(.focused).rect | "\(.x),\(.y) \(.width)x\(.height)"'
+set $focused_output swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name'
+# Screenshot commands
+set $screenshot_full grim
+set $screenshot_focused_output grim -o $($focused_output)
+set $screenshot_focused_window $focused_window | grim -g-
+set $screenshot_selected_window $selected_window | grim -g-
+set $screenshot_selected_area slurp | grim -g-
+# Screenshot keybindings
+bindsym Print exec $screenshot_full
+bindsym $mod+Print exec $screenshot_focused_output
+bindsym Shift+Print exec $screenshot_focused_window
+bindsym Mod1+Print exec $screenshot_selected_window
+bindsym Ctrl+Print exec $screenshot_selected_area
+
 #
 # Status Bar:
 #

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -43,6 +43,7 @@ Requires:       gfxboot-branding-openSUSE
 Requires:       git
 Requires:       greetd
 Requires:       grep
+Recommends:     grim
 Requires:       gzip
 Requires:       (gtkgreet or wlgreet)
 Suggests:       imv
@@ -60,6 +61,7 @@ Suggests:       vim
 Requires:       clipman
 Requires:       wl-clipboard
 Requires:       mpris-ctl
+Recommends:     slurp
 Requires:       sway-marker
 Requires:       waybar-branding-openSUSE
 Requires:       wget


### PR DESCRIPTION
This is my screenshot configuration using `grim` and `slurp`. It allows to:
- `Print`: screenshot all outputs
- `$mod + Print`: screenshot the focused output
- `Shift + Print`: screenshot the focused window
- `Mod1 + Print`: screenshot an interactively selected window
- `Ctrl + Print`: screenshot an interactively selected area

Before I merge this PR, I want to open this to contributions if others have better configurations.