### PR TITLE
Fix missing glyphs on the default style

### DIFF
--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -1,7 +1,7 @@
 * {
     border:        none;
     border-radius: 0;
-    font-family:   "Source Sans Pro";
+    font-family:   "Source Sans Pro", "FontAwesome 6 Free";
     font-size:     15px;
     box-shadow:    none;
     text-shadow:   none;


### PR DESCRIPTION
The default style uses some glyphs for the config (ie battery full) that are depending on the private use area of Unicode. The style defines only Source Sans Pro as a font which does not contain these glyphs, and instead displays Chinese glyphs.

This fixes part of this, but an SR making the waybar package depend on the fontawesome-font package is also needed.