### PR TITLE
Convert Waybar tooltip calendar to new format (>=0.9.18)

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -67,13 +67,25 @@
     "clock": {
         // "timezone": "America/New_York",
         "format": " {:%b %d %Y %R}",
-        "tooltip-format": "<span color='#35b9ab'><big>{:%Y %B}</big></span>\n<span color='#35b9ab'><tt><small>{calendar}</small></tt></span>",
         "format-alt": "{:%a %d %b w:%V %H:%M}",
-        "today-format": "<span color='#21a4df'><b><u>{}</u></b></span>",
-        "calendar-weeks-pos": "left",
-        "format-calendar": "<span background='#173f4f' bgalpha='60%'><b>{}</b></span>",
-        "format-calendar-weeks": "<span color='#73ba25'><b>{}</b></span>",
-        "format-calendar-weekdays": "<span color='#21a4df'><b>{}</b></span>",
+        "tooltip-format": "<span color='#35b9ab'><tt><small>{calendar}</small></tt></span>",
+        "calendar": {
+            "mode-mon-col"      : 4,
+            "weeks-pos"         : "left",
+            "on-scroll"         : 1,
+            "on-click-right"    : "mode",
+            "format": {
+                "months":    "<span color='#35b9ab'><b>{}</b></span>",
+                "weeks":    "<span color='#73ba25'><b>{}</b></span>",
+                "weekdays": "<span color='#21a4df'><b>{}</b></span>",
+                "today":    "<span color='#21a4df'><b><u>{}</u></b></span>"
+            }
+        },
+        "actions": {
+            "on-click-right"    : "mode",
+            "on-scroll-up"      : "shift_up",
+            "on-scroll-down"      : "shift_down"
+        },
         "interval": 10
     },
     "cpu": {


### PR DESCRIPTION
Here is the fix for our tooltip calendar configuration.

I've also added configuration for a couple of new features available in the Waybar clock module from version 0.9.18:

- right clicking the clock toggles the calendar from single month to full year
- scrolling on the clock moves the calendar up or down by 1 month at a time

Quite nifty if you ask me.

The year calendar is broken for me at the moment, but I don't think it's the configuration - I've submitted https://github.com/Alexays/Waybar/issues/2240 for it.

Fixes #119 