### PR TITLE
Add bluetooth waybar module

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -7,7 +7,7 @@
     // Choose the order of the modules
     "modules-left": ["sway/workspaces", "custom/scratchpad", "sway/mode", "tray"],
     "modules-center": ["sway/window"],
-    "modules-right": ["custom/zypper", "network", "cpu", "memory", "temperature", "backlight", "battery", "battery#bat2", "pulseaudio", "custom/layout", "clock", "custom/notification"],
+    "modules-right": ["custom/zypper", "network", "bluetooth", "cpu", "memory", "temperature", "backlight", "battery", "battery#bat2", "pulseaudio", "custom/layout", "clock", "custom/notification"],
     "sway/mode": {
         "format": " {}"
     },
@@ -130,6 +130,22 @@
         "format-linked": "",
         "format-disconnected": "⚠",
         "format-alt": "{ifname} {essid} ({signalStrength}%)"
+    },
+    "bluetooth": {
+	"format": "",
+	"format-disabled": "",
+	"format-off": "",
+	"format-connected": " {num_connections}",
+	// "format-connected": " {device_alias}",
+	"tooltip-format": "{controller_address} {status}\n\n{num_connections} connected",
+	"tooltip-format-disabled": "{status}",
+	"tooltip-format-connected": "{controller_address}\n\n{num_connections} connected\n\n{device_enumerate}",
+	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
+	"format-connected-battery": " {device_alias} {device_battery_percentage}%",
+	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%",
+	// "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device
+	"on-click": "bluetooth toggle; pkill -SIGRTMIN+8 waybar",
+	"on-click-right": "exec alacritty -e sh -c 'bluetoothctl'"
     },
     "pulseaudio": {
         "format": "{icon}",

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -49,6 +49,7 @@ window#waybar.solo {
 #cpu, 
 #memory, 
 #network, 
+#bluetooth,
 #pulseaudio, 
 #idle_inhibitor, 
 #temperature,
@@ -74,3 +75,14 @@ window#waybar.solo {
     color: rgba(217, 216, 216, 1);
 }
 
+#bluetooth.disabled {
+    color: rgba(128, 128, 128, 1);
+}
+
+#bluetooth.off {
+    color: rgba(128, 128, 128, 1);
+}
+
+#bluetooth.connected {
+    color: rgba(115, 186, 37, 1);
+}

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -35,6 +35,7 @@ BuildRequires:  pkgconfig(systemd)
 Requires:       NetworkManager
 Requires:       aaa_base
 Recommends:     adwaita-qt5
+Recommends:     bluez
 Requires:       bzip2
 Requires:       command-not-found
 Requires:       curl
@@ -55,6 +56,7 @@ Recommends:     qt5ct
 Requires:       sudo
 Requires:       sway-branding-openSUSE
 Requires:       tar
+Recommends:     tlp
 Suggests:       vifm
 Suggests:       vim
 Requires:       clipman


### PR DESCRIPTION
This is my waybar bluetooth module I've had forever.

Features:

- color coded: neutral color when on but disconnected, greyed out when disabled, green (with number of connected devices) when connected
- tooltip shows controller address (not too useful but it's there), connection status, and number of connected devices if any
- left click toggles bluetooth on/off
- right click opens a terminal with bluetoothctl (could use some improvement on e.g. opening $TERM instead of fixed alacritty)