### PR TITLE
Migrate Alacritty configuration to TOML

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,0 +1,2 @@
+[window]
+opacity = 0.4

--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -1,2 +1,0 @@
-window:
-  opacity: 0.4

--- a/.config/sway/config
+++ b/.config/sway/config
@@ -14,7 +14,7 @@ set $down j
 set $up k
 set $right l
 # Your preferred terminal emulator
-set $term alacritty --config-file /etc/alacritty/alacritty.yml
+set $term alacritty --config-file /etc/alacritty/alacritty.toml
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -158,7 +158,7 @@ install -D -p -m 755 sway/sway-run.sh %{buildroot}%{_bindir}/sway-run.sh
 
 ### alacritty
 # so far doesn't have special branding package and it doesn't support system wide config
-install -D -p -m 644 .config/alacritty/alacritty.yml %{buildroot}%{_sysconfdir}/alacritty/alacritty.yml
+install -D -p -m 644 .config/alacritty/alacritty.toml %{buildroot}%{_sysconfdir}/alacritty/alacritty.toml
 
 ## wofi
 install -D -p -m 644 .config/wofi/config %{buildroot}%{_sysconfdir}/wofi/config
@@ -236,7 +236,7 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %{_bindir}/sway-run.sh
 
 %dir %{_sysconfdir}/alacritty
-%config(noreplace) %{_sysconfdir}/alacritty/alacritty.yml
+%config(noreplace) %{_sysconfdir}/alacritty/alacritty.toml
 
 %dir %{_sysconfdir}/wofi
 %config(noreplace) %{_sysconfdir}/wofi/config


### PR DESCRIPTION
YAML configuration is deprecated as of Alacritty version 0.13.0.

Resolve this banner for new users:

![image](https://github.com/openSUSE/openSUSEway/assets/5121046/d510649c-e45e-4599-bc8e-44273a7acf65)

Users with a custom Alacritty/Sway configuration need to migrate and update on their own, I think it is not a good idea to call the migration in a post script as users might have more complex YAML configurations.

See https://github.com/alacritty/alacritty/issues/6592.