### PR TITLE
Add screenshot mode menu

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -49,23 +49,53 @@ bindsym --no-warn XF86AudioPlay exec playerctl play-pause
 bindsym --no-warn XF86AudioNext exec playerctl next
 bindsym --no-warn XF86AudioPrev exec playerctl previous
 
-## Screenshots
-# Area selection shortcuts
+# Screenshots
+## Area selection shortcuts
 set $selected_window swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp
 set $focused_window swaymsg -t get_tree | jq -j '.. | select(.type?) | select(.focused).rect | "\(.x),\(.y) \(.width)x\(.height)"'
 set $focused_output swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name'
-# Screenshot commands
+## Screenshot commands
+### Full
 set $screenshot_full grim
-set $screenshot_focused_output grim -o $($focused_output)
-set $screenshot_focused_window $focused_window | grim -g-
+set $screenshot_full_clipboard grim - | wl-copy
+### Selected window
 set $screenshot_selected_window $selected_window | grim -g-
+set $screenshot_selected_window_clipboard $selected_window | grim -g- - | wl-copy
+### Selected area
 set $screenshot_selected_area slurp | grim -g-
-# Screenshot keybindings
-bindsym Print exec $screenshot_full
-bindsym $mod+Print exec $screenshot_focused_output
-bindsym Shift+Print exec $screenshot_focused_window
-bindsym Mod1+Print exec $screenshot_selected_window
-bindsym Ctrl+Print exec $screenshot_selected_area
+set $screenshot_selected_area_clipboard slurp | grim -g- - | wl-copy
+### Focused window
+set $screenshot_focused_window $focused_window | grim -g-
+set $screenshot_focused_window_clipboard $focused_window | grim -g- - | wl-copy
+### Focused output
+set $screenshot_focused_output grim -o $($focused_output)
+set $screenshot_focused_output grim -o $($focused_output) - | wl-copy
+
+## Screenshot mode menu
+set $screenshot "Screenshot: (f) full, (s) select window, (a) select area, (w) focused window, (o) focused output [Ctrl+ saves to clipboard]"
+mode $screenshot {
+    # Full
+    bindsym f exec $screenshot_full; mode "default"
+    bindsym Ctrl+f exec $screenshot_full_clipboard; mode "default"
+    # Selected window
+    bindsym s exec $screenshot_selected_window; mode "default"
+    bindsym Ctrl+s exec $screenshot_selected_window_clipboard; mode "default"
+    # Selected area
+    bindsym a exec $screenshot_selected_area; mode "default"
+    bindsym Ctrl+a exec $screenshot_selected_area_clipboard; mode "default"
+    # Focused window
+    bindsym w exec $screenshot_focused_window; mode "default"
+    bindsym Ctrl+w exec $screenshot_focused_window_clipboard; mode "default"
+    # Focused output
+    bindsym o exec $screenshot_focused_output; mode "default"
+    bindsym Ctrl+o exec $screenshot_focused_output_clipboard; mode "default"
+
+    # Exit screenshot mode menu
+    bindsym Return mode "default"
+    bindsym Escape mode "default"
+    bindsym $mod+Print mode "default"
+}
+bindsym $mod+Print mode $screenshot
 
 #
 # Status Bar:


### PR DESCRIPTION
This adds a screenshot mode menu instead of the individual screenshot options. The mode menu can be opened with `$mod+Print` and displays this text:

`Screenshot: (f) full, (s) select window, (a) select area, (w) focused window, (o) focused output [Ctrl+ saves to clipboard]`

The text is a bit long, and might not display fully in the bar depending on leftover space. Hovering over the menu text displays a tooltip with the full text, however.

The options should be quite intuitive.

- `f` takes a screenshot of all visible outputs
- `s` prompts the user to select a window and takes a screenshot of that
- `a` prompts the user to select a rectangular area and takes a screenshot of that
- `w` takes a screenshot of the window currently under focus
- `o` takes a screenshot of the output currently under focus

Pressing `<option>` saves the screenshot into `a timestamped file name in $GRIM_DEFAULT_DIR [...]. If $GRIM_DEFAULT_DIR is not set, it falls back first to $XDG_PICTURES_DIR and then to  the  current working directory` (from `man grim`).

 Pressing `Ctrl+<option>` writes the screenshot to the clipboard instead.