### PR TITLE
Change "dpms" to "power"

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -38,7 +38,7 @@ output * bg /usr/share/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 #
 # exec swayidle -w \
 #          timeout 300 'swaylock -f -c 000000' \
-#          timeout 600 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"' \
+#          timeout 600 'swaymsg "output * power off"' resume 'swaymsg "output * power on"' \
 #          before-sleep 'swaylock -f -c 000000'
 #
 # This will lock your screen after 300 seconds of inactivity, then turn off

--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -25,8 +25,8 @@ set $screenlock 'swaylock -f -c 000000'
 # Idle configuration
 exec swayidle -w \
          timeout 300 $screenlock \
-         timeout 600 'swaymsg "output * dpms off"' \
-              resume 'swaymsg "output * dpms on"' \
+         timeout 600 'swaymsg "output * power off"' \
+              resume 'swaymsg "output * power on"' \
          before-sleep $screenlock
 
 bindsym --to-code {


### PR DESCRIPTION
The idle configuration uses "output * dpms on/off" to switch off the monitors.

According to the man-page of sway-output "dpms" is an alias for "power" and depricated.
This change would make the configuration compliant with the current settings of sway and swayidle, which both use "power".

Since the configuration serves as a reference for many users, it makes sense to adapt this setting to the current recommendation. 