### PR TITLE
Screenshot_focused_output misses clipboard

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -69,7 +69,7 @@ set $screenshot_focused_window $focused_window | grim -g-
 set $screenshot_focused_window_clipboard $focused_window | grim -g- - | wl-copy
 ### Focused output
 set $screenshot_focused_output grim -o $($focused_output)
-set $screenshot_focused_output grim -o $($focused_output) - | wl-copy
+set $screenshot_focused_output_clipboard grim -o $($focused_output) - | wl-copy
 
 ## Screenshot mode menu
 set $screenshot "Screenshot: (f) full, (s) select window, (a) select area, (w) focused window, (o) focused output [Ctrl+ saves to clipboard]"


### PR DESCRIPTION
Instead of $screenshot_focused_output_clipboard the variable $screenshot_focused_output was set two times