### PR TITLE
Suggestion: Add path for screenshots

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -50,25 +50,27 @@ bindsym --no-warn XF86AudioNext exec playerctl next
 bindsym --no-warn XF86AudioPrev exec playerctl previous
 
 # Screenshots
+## Screenshot file path
+set $screenshot_dir $(xdg-user-dir PICTURES)/$(date +%Y-%m-%d_%H-%M-%S).png
 ## Area selection shortcuts
 set $selected_window swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp
 set $focused_window swaymsg -t get_tree | jq -j '.. | select(.type?) | select(.focused).rect | "\(.x),\(.y) \(.width)x\(.height)"'
 set $focused_output swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name'
 ## Screenshot commands
 ### Full
-set $screenshot_full grim
+set $screenshot_full grim $screenshot_dir
 set $screenshot_full_clipboard grim - | wl-copy
 ### Selected window
-set $screenshot_selected_window $selected_window | grim -g-
+set $screenshot_selected_window $selected_window | grim -g- $screenshot_dir
 set $screenshot_selected_window_clipboard $selected_window | grim -g- - | wl-copy
 ### Selected area
-set $screenshot_selected_area slurp | grim -g-
+set $screenshot_selected_area slurp | grim -g- $screenshot_dir
 set $screenshot_selected_area_clipboard slurp | grim -g- - | wl-copy
 ### Focused window
-set $screenshot_focused_window $focused_window | grim -g-
+set $screenshot_focused_window $focused_window | grim -g- $screenshot_dir
 set $screenshot_focused_window_clipboard $focused_window | grim -g- - | wl-copy
 ### Focused output
-set $screenshot_focused_output grim -o $($focused_output)
+set $screenshot_focused_output grim -o $($focused_output) $screenshot_dir
 set $screenshot_focused_output_clipboard grim -o $($focused_output) - | wl-copy
 
 ## Screenshot mode menu


### PR DESCRIPTION
The path for screenshots was discussed in PR [#117](https://github.com/openSUSE/openSUSEway/pull/117).

A possible solution could be to define the path for the file location as a variable in the config and then pass it to grim.
Example of how it would be saved: `$XDG_PICTURES_DIR/2024-02-09_13-51-47.png` instead of `$XDG_PICTURES_DIR/20240209_13h51m47s_grim.png`.


Advantages:
- The directory and name of the screenshots can be easily changed.
- Would give the possibility to further manipulate the name
> e.g. focused window is saved with window name:
> ```
> set $screenshot_dir $(xdg-user-dir PICTURES)/$(date +%Y-%m-%d_%H-%M-%S)
> set $screenshot_focused_window $focused_window | grim -g- $screenshot_dir_$(swaymsg -t get_tree | jq -j '.. | select(.type?) | select(.focused).app_id').png
> ```

This would still not save the images in the screenshots subdirectory, because it is not clear whether the user has this directory.

Not sure if you are interested in this change.