### PR TITLE
Change workspace indicator to number, keep logo only on active workspace

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -14,11 +14,11 @@
     "sway/workspaces": {
         "all-outputs": false,
         "disable-scroll": true,
-        "format": " {icon} ",
+        "format": "{index} {icon}",
         "format-icons": {
             "urgent": "",
             "focused": "",
-            "default": ""
+            "default": ""
         }
     },
     "sway/window": {


### PR DESCRIPTION
Change waybar workspace appearance from:
![image](https://github.com/openSUSE/openSUSEway/assets/101266837/cd7d57de-e922-44c8-a7f0-5b125658427f)
to
![20240226_10h05m22s_grim](https://github.com/openSUSE/openSUSEway/assets/101266837/1d54aa1d-d24c-4b05-baf1-50047678e6dc)


Fix #141 