### PR TITLE
Replace Fontawesome SUSE logo (f7d6) with openSUSE (e62b)

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -16,8 +16,8 @@
         "disable-scroll": true,
         "format": "{index} {icon}",
         "format-icons": {
-            "urgent": "",
-            "focused": "",
+            "urgent": "",
+            "focused": "",
             "default": ""
         }
     },


### PR DESCRIPTION
Fix #143 