### PR TITLE
Increase lock timer duration

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -24,8 +24,8 @@ bindsym $mod+Shift+tab workspace prev_on_output
 set $screenlock 'swaylock -f -c 000000'
 # Idle configuration
 exec swayidle -w \
-         timeout 300 $screenlock \
-         timeout 600 'swaymsg "output * power off"' \
+         timeout 900 $screenlock \
+         timeout 960 'swaymsg "output * power off"' \
               resume 'swaymsg "output * power on"' \
          before-sleep $screenlock
 


### PR DESCRIPTION
Increase lock timer to 15 minutes. After one additional minute, turn screens off.

Fix #150.