### PR TITLE
Remove examples from NC config

### DIFF
--- a/.config/swaync/config.json
+++ b/.config/swaync/config.json
@@ -21,18 +21,5 @@
   "transition-time": 200,
   "hide-on-clear": false,
   "hide-on-action": true,
-  "script-fail-notify": true,
-  "scripts": {
-    "example-script": {
-      "exec": "echo 'Do something...'",
-      "urgency": "Normal"
-    }
-  },
-  "notification-visibility": {
-    "example-name": {
-      "state": "muted",
-      "urgency": "Low",
-      "app-name": "Spotify"
-    }
-  }
+  "script-fail-notify": true
 }


### PR DESCRIPTION
It looks like it works much better without it. Recently I got "Do something" notification, which is just an example.