### PR TITLE
Fix JSON parsing issue that was preventing waybar from launching

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -32,7 +32,7 @@
     "custom/zypper": {
         "format": "{} ",
         "interval": 3600,
-        "exec": "zypper lu | grep 'v \+|' | wc -l; echo 'packages to update'",
+        "exec": "zypper lu | grep 'v \\+|' | wc -l; echo 'packages to update'",
         "exec-if": "exit 0",
         "on-click": "exec alacritty -e sudo sh -c 'zypper ref; zypper dup; pkill -SIGRTMIN+8 waybar'",
         "signal": 8


### PR DESCRIPTION
After initial install of openSUSEway waybar wasn't launching.So I decided to check what's up by running waybar from commandline and  got this error
 ```
 [info]Using configuration file /etc/xdg/waybar/config 
 [error]Error parsing JSON: * Line 35, Column 17
       Bad escape sequence in string
 See Line 35, Column 40 for detail
```
Double escaping the '+' in line 35 fixed the issue for me
``` js
"exec": "zypper lu | grep 'v \+|' | wc -l; echo 'packages to update'",
```