### PR TITLE
New background

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,2 +1,2 @@
 [window]
-opacity = 0.4
+opacity = 0.75

--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -7,7 +7,7 @@
 set $menu wofi --show drun,run
 
 # openSUSE wallpaper
-output * bg /usr/share/wallpapers/default-1920x1080.png fill
+output * bg /usr/share/wallpapers/openSUSEdefault/contents/images/default-dark.png fill
 
 # Enable common options for generic touchpads
 input "type:touchpad" {

--- a/.config/swaylock/openSUSEway.conf
+++ b/.config/swaylock/openSUSEway.conf
@@ -11,4 +11,4 @@ line-uses-ring
 # Show caps lock indicator
 indicator-caps-lock
 # Background image
-image=/usr/share/wallpapers/default-1920x1080.png
+image=/usr/share/wallpapers/openSUSEdefault/contents/images/default-dark.png

--- a/greetd/style.css
+++ b/greetd/style.css
@@ -1,5 +1,5 @@
 window {
-	background-image: url("file:///usr/share/wallpapers/default-1920x1080.png");
+	background-image: url("file:///usr/share/wallpapers/openSUSEdefault/contents/images/default-dark.png");
 	background-size: cover;
 	background-position: center;
 	color: rgba(53, 185, 171, 1);

--- a/greetd/style.css
+++ b/greetd/style.css
@@ -3,6 +3,7 @@ window {
 	background-size: cover;
 	background-position: center;
 	color: rgba(53, 185, 171, 1);
+	box-shadow: inset 0 0 0 8000px rgba(1, 1, 1, 0.4);
 }
 entry {
 	color: rgba(115, 186, 37, 1);


### PR DESCRIPTION
Use new openSUSE default dark background. Raise alacritty opacity to `0-75`, experimentally determined to look nice with the new background:
![image](https://github.com/user-attachments/assets/72ec6065-7297-4d8f-bd77-15dd729fd4af)

Fix #175 