### PR TITLE
waybar-branding-openSUSE: add fonts as dependencies

### DIFF
--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -159,6 +159,8 @@ BuildRequires:  waybar
 Provides:       waybar-branding = %{version}
 Conflicts:      waybar-branding
 Supplements:    (waybar and branding-openSUSE)
+Requires:       adobe-sourcesanspro-fonts
+Requires:	fontawesome-fonts
 
 #BRAND: /etc/xdg/waybar/config and /etc/xdg/waybar/style.css
 #BRAND: contain openSUSE config and branding


### PR DESCRIPTION
fixes #178 

The fonts should be dependencies of the branding package itself, not the meta package.

This PR adds the used fonts of `waybar-branding-openSUSE` as requirements to it.

I did not dare to remove any fonts from the meta package but I am guessing that most of them should be specified in the branding packages.