### PR TITLE
waybar style.css: make workspace and scratchpad have no left margins

### DIFF
--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -19,11 +19,11 @@ window#waybar.solo {
 }
 
 #workspaces {
-    margin: 0 5px;
+    margin-right: 5px;
 }
 
 #custom-scratchpad {
-    margin: 0px	5px;
+    margin-right: 5px;
     padding: 0px 5px;
 }
 


### PR DESCRIPTION
Currently the workspaces have a 5px margin to the left and right.

This has been bugging me because this means that there are 5 pixels to the left of the workspaces where the first workspace cannot be clicked.

Buttons in corners should always be clickable from the entire corner, to support [Fitt's Law](https://en.wikipedia.org/wiki/Fitts's_law). Having a button in the corner essentially makes the button infinitely bug because you can click it no matter how far you move the cursor into the corner.

So that's why I removed that 5px margin, now you can slam your mouse into the corner and always be able to click on the first workspace.

I also removed the left margin on the scratchpad. Combined with the margin from the workspaces the margin between the workspaces and scratchpad would've been 10px.

This puts the scratchpad in a bit of an awkward distance from the workspaces, but it looks especially bad when having a task tray app.

Because task tray apps do not have a margin so they're only 5px away from the workspaces making the margin of the scratchpad inconsistent.

Anyway the simple solution to both of these issues is to remove the left margin on the workspaces and scratchpad.