### PR TITLE
Remove unused bsah-completion dependency

### DIFF
--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -35,7 +35,6 @@ BuildRequires:  pkgconfig(systemd)
 # system
 Requires:       wget
 Requires:       glibc-locale
-Requires:       bash-completion
 Requires:       NetworkManager
 Requires:       aaa_base
 Requires:       bzip2


### PR DESCRIPTION
The dependency on `bash-completion` will obviously pull in the package, along with all the other completion packages such as `btrfsprogs-bash-completion` for packages installed on the system. Attempting to remove `bash-completion` will want to remove `openSUSEway` due to the hard dependency.

`bash-completion` isn't strictly required as `bash` isn't strictly required for `openSUSEway`, and so this dependency is annoying for those who want to use a different shell.

I believe `bash-completion` is installed by default on new installations, so in terms of "user friendliness" removing the dependency shouldn't change that experience.