### PR TITLE
Add client indicator and child_border colors for focused window

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -127,7 +127,7 @@ bindsym $mod+Shift+n exec $toggle_notification
 # openSUSE theme
 default_border pixel 2
 gaps inner 10
-client.focused #6da741 #173f4f #73ba25
+client.focused #6da741 #173f4f #73ba25 #6da741 #00a489
 client.unfocused #00a489 #173f4f #35b9ab
 client.focused_inactive #6da741 #00a489 #173f4f
 


### PR DESCRIPTION
Add client `indicator` and `child_border` color for focused window, which previously only featured the three main required colors.

From `man 5 sway`:
```manpage
client.<class> <border> <background> <text> [<indicator> [<child_border>]]
           Configures  the  color  of window borders and title bars. The first three colors are required.
           When omitted indicator will use a sane default and child_border will use  the  color  set  for
           background. Colors may be specified in hex, either as #RRGGBB or #RRGGBBAA.

...

indicator
               The color used to indicate where a new view will open. In a tiled  container,  this  would
               paint the right border of the current view if a new view would be opened to the right.

child_border
               The border around the view itself.
```

I've picked our dull green color (`#6da741`) for the indicator, and our generic light blue highlight color (`#00a489`) for the child_border.

This is what they look like:

![image](https://github.com/user-attachments/assets/b69a3231-8e34-4d97-9536-2c69d530b7d2)

Fixes #188 
