### PR TITLE
Improve waybar pulseaudio module configuration

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -164,7 +164,7 @@
         "scroll-step": 10,
         "on-click": "pactl set-sink-mute @DEFAULT_SINK@ toggle",
         "on-click-right": "pavucontrol",
-        "tooltip": false
+        "tooltip": true
     },
     "custom/scratchpad": {
         "format-text": "{}",

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -150,7 +150,7 @@
     "pulseaudio": {
         "format": "{icon}",
         "format-alt": "{volume} {icon}",
-        "format-alt-click": "click-right",
+        "format-alt-click": "click-middle",
         "format-muted": "",
         "format-icons": {
             "headphones": "",


### PR DESCRIPTION
Toggle pulseaudio module alt format (number) with middle click instead of right click, which would collide with the right-click action (opening `pavucontrol`).

Also enable the tooltip while we're at it.

Fixes #190 