### PR TITLE
Improve network widget

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -131,6 +131,7 @@
         "format-disconnected": "⚠",
         "tooltip-format": "Interface: {ifname}\nAddress: {ipaddr}\nU: {bandwidthUpBytes} D: {bandwidthDownBytes}",
         "tooltip-format-wifi": "{essid} ({signalStrength}%) ({frequency} GHz)\nInterface: {ifname}\nAddress: {ipaddr}\nU: {bandwidthUpBytes} D: {bandwidthDownBytes}",
+        "on-click-right": "exec alacritty -e sh -c 'nmtui'"
     },
     "bluetooth": {
 	"format": "",

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -129,7 +129,8 @@
         "format-ethernet": "",
         "format-linked": "",
         "format-disconnected": "⚠",
-        "format-alt": "{ifname} {essid} ({signalStrength}%)"
+        "tooltip-format": "Interface: {ifname}\nAddress: {ipaddr}\nU: {bandwidthUpBytes} D: {bandwidthDownBytes}",
+        "tooltip-format-wifi": "{essid} ({signalStrength}%) ({frequency} GHz)\nInterface: {ifname}\nAddress: {ipaddr}\nU: {bandwidthUpBytes} D: {bandwidthDownBytes}",
     },
     "bluetooth": {
 	"format": "",


### PR DESCRIPTION
- Show network information in the tooltip
  - Instead of clicking to see an alternative representation of the network  widget, show the network information in the tooltip.
  - For a generic network show the interface name, IP address, and up/down bandwidth statistics.
  - If the network is wifi, also show the essid, signal strength and wifi frequency.
- Right click the network widget to open nmtui