### PR TITLE
Remove requirement for NetworkManager

### DIFF
--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -36,7 +36,6 @@ BuildRequires:  pkgconfig(systemd)
 # system
 Requires:       wget
 Requires:       glibc-locale
-Requires:       NetworkManager
 Requires:       aaa_base
 Requires:       bzip2
 Requires:       command-not-found


### PR DESCRIPTION
I don't use NetworkManager on my machine, and openSUSEway works fine without it. Installing a network management solution should be part of a base system pattern and not part of the desktop environment.