### PR TITLE
Make it possible to have system-specific configuration for sway

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -217,4 +217,5 @@ bindsym $mod+r mode "resize"
 #}
 
 include /etc/sway/config.d/*.conf
-include ~/.config/sway/config.d/*
+include ~/.config/sway/config.d/*.conf
+include ~/.config/sway/config.$(hostname)/*.conf


### PR DESCRIPTION
When sharing same configuration for all my personal systems, it is quite useful to have some system-specific (e.g., hardware-related configuration).