### PR TITLE
Bluetooth improvements

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -146,7 +146,7 @@
 	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%",
 	// "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device
 	"on-click": "bluetooth toggle; pkill -SIGRTMIN+8 waybar",
-	"on-click-right": "exec alacritty -e sh -c 'bluetoothctl'"
+	"on-click-right": "exec alacritty -e sh -c 'bluetuith'"
     },
     "pulseaudio": {
         "format": "{icon}",

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -145,7 +145,7 @@
 	"format-connected-battery": " {device_alias} {device_battery_percentage}%",
 	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%",
 	// "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device
-	"on-click": "bluetooth toggle; pkill -SIGRTMIN+8 waybar",
+	"on-click": "bluetoothctl power $(bluetoothctl show | grep -q 'Powered: yes' && echo off || echo on); pkill -SIGRTMIN+8 waybar",
 	"on-click-right": "exec alacritty -e sh -c 'bluetuith'"
     },
     "pulseaudio": {

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -55,7 +55,7 @@ Requires:       sway-marker
 Recommends:     grim
 Recommends:     slurp
 Recommends:     firefox
-Recommends:     bluez
+Recommends:     bluetuith
 Recommends:     tlp
 Suggests:       mpv
 Suggests:       vifm


### PR DESCRIPTION
This PR improves bluetooth handling in openSUSEway.

- Use `bluetuith` for interactive bluetooth management
  `bluetuith` still requires `bluez`, so `bluetoothctl` (provided by `bluez`) remains available for non-interactive use.
- Use `bluetoothctl` to toggle bluetooth power in Waybar
   The previously used `bluetooth` binary is provided by the `tlp` package, which is not a requirement of openSUSEway and is not (anymore?) installed by default on openSUSE Tumbleweed.

Fixes #163 