### PR TITLE
Cycle through windows with Mod1+Tab (Alt+Tab)

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -21,6 +21,13 @@ input "type:touchpad" {
 bindsym $mod+tab workspace next_on_output
 bindsym $mod+Shift+tab workspace prev_on_output
 
+# Cycle through windows
+bindsym Mod1+Tab focus next
+bindsym Mod1+Shift+Tab focus prev
+
+# Wrap focus next/prev to workspace, even if other outputs are found in the movement direction
+# focus_wrapping force
+
 # Lockscreen configuration
 set $screenlock 'swaylock --config /etc/swaylock/openSUSEway.conf'
 # Idle configuration


### PR DESCRIPTION
On top of cycling with Alt-Tab, I also have focus wrapping enabled in my configuration.

From `man 5 sway`:

> **focus_wrapping yes|no|force|workspace**
> This option determines what to do when attempting to focus over the edge of a container. If set to no, the focused container will retain focus, if there are no other containers in the direction. If set to yes, focus will be wrapped to the opposite edge of the container, if there are no other containers in the direction. If set to force, focus will be wrapped to the opposite  edge  of  the  container, even if there are other containers in the direction. If set to workspace, focus will wrap like in the yes case and additionally wrap when moving outside of workspaces boundaries. Default is yes.

I have not set the `focus_wrapping force` option in this PR, but I've added it as a comment for reference so that users can more easily be aware of the possibility, and can decide to set it for themselves if desired.