### PR TITLE
Allow volume to show over 100% in wob

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -41,8 +41,8 @@ bindsym XF86AudioMicMute exec pactl set-source-mute @DEFAULT_SOURCE@ toggle
 bindsym XF86MonBrightnessDown exec brightnessctl -q set 5%- && ( echo $((`brightnessctl get` * 100 / `brightnessctl m`)) > $SWAYSOCK.wob )
 bindsym XF86MonBrightnessUp exec brightnessctl -q set +5% && ( echo $((`brightnessctl get` * 100 / `brightnessctl m`)) > $SWAYSOCK.wob )
 
-bindsym XF86AudioRaiseVolume exec pamixer --allow-boost -ui 2 && dc -e "[`pamixer --get-volume`]sM 100d `pamixer --get-volume`<Mp" > $SWAYSOCK.wob
-bindsym XF86AudioLowerVolume exec pamixer --allow-boost -ud 2 && dc -e "[`pamixer --get-volume`]sM 100d `pamixer --get-volume`<Mp" > $SWAYSOCK.wob
+bindsym XF86AudioRaiseVolume exec pamixer --allow-boost -ui 2 && pamixer --get-volume > $SWAYSOCK.wob
+bindsym XF86AudioLowerVolume exec pamixer --allow-boost -ud 2 && pamixer --get-volume > $SWAYSOCK.wob
 bindsym XF86AudioMute exec pamixer --toggle-mute && ( pamixer --get-mute && echo 0 > $SWAYSOCK.wob )
 
 # Media player controls

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -128,7 +128,6 @@ Summary:        openSUSE branding of sway
 Group:          System/GUI/Other
 BuildRequires:  sway
 Requires:       SwayNotificationCenter
-Requires:       bc
 Requires:       brightnessctl
 Requires:       fontawesome-fonts
 Requires:       jq


### PR DESCRIPTION
Volume boost was enabled in d19c2677790013fa35aff8d1a92b010c3855cb78 in #31, but back then `wob` was capped to showing a maximum value of 100. This limitation no longer holds, and our `wob` configuration already supports showing values over 100 as a red bar.