### PR TITLE
Detect user conf

### DIFF
--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -148,7 +148,7 @@ exec_always {
     gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
     test -e $SWAYSOCK.wob || mkfifo $SWAYSOCK.wob
     tail -f $SWAYSOCK.wob | $wob
-    swaync --style /etc/sway/swaync/style.css --config /etc/sway/swaync/config.json
+    /usr/share/openSUSEway/helpers/swaync.sh
 }
 
 exec /usr/libexec/polkit-gnome-authentication-agent-1

--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -34,12 +34,6 @@ bindsym Mod1+Shift+Tab focus prev
 
 # Lockscreen configuration
 set $screenlock 'swaylock --config /etc/swaylock/openSUSEway.conf'
-# Idle configuration
-exec swayidle -w \
-         timeout 900 $screenlock \
-         timeout 960 'swaymsg "output * power off"' \
-              resume 'swaymsg "output * power on"' \
-         before-sleep $screenlock
 
 bindsym --to-code {
     $mod+b splith
@@ -146,6 +140,11 @@ exec_always {
     gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
     /usr/share/openSUSEway/helpers/swaync.sh
     /usr/share/openSUSEway/helpers/wob.sh
+    /usr/share/openSUSEway/helpers/swayidle.sh || exec swayidle -w \
+         timeout 900 $screenlock \
+         timeout 960 'swaymsg "output * power off"' \
+              resume 'swaymsg "output * power on"' \
+         before-sleep $screenlock
 }
 
 exec /usr/libexec/polkit-gnome-authentication-agent-1

--- a/.config/sway/config.d/50-openSUSE.conf
+++ b/.config/sway/config.d/50-openSUSE.conf
@@ -138,17 +138,14 @@ client.focused #6da741 #173f4f #73ba25 #6da741 #00a489
 client.unfocused #00a489 #173f4f #35b9ab
 client.focused_inactive #6da741 #00a489 #173f4f
 
-set $wob wob --config /etc/sway/wob/wob.ini
-
 exec_always {
     systemctl --user import-environment
     gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
     gsettings set org.gnome.desktop.interface icon-theme 'Adwaita'
     gsettings set org.gnome.desktop.interface cursor-theme 'Adwaita'
     gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
-    test -e $SWAYSOCK.wob || mkfifo $SWAYSOCK.wob
-    tail -f $SWAYSOCK.wob | $wob
     /usr/share/openSUSEway/helpers/swaync.sh
+    /usr/share/openSUSEway/helpers/wob.sh
 }
 
 exec /usr/libexec/polkit-gnome-authentication-agent-1

--- a/helpers/swayidle.sh
+++ b/helpers/swayidle.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Load the user's home swayidle configuration, if found.
+# Otherwise return 1 to default to the openSUSEway configuration.
+
+SWAYIDLE_HOME_CONFIG="$HOME/.config/swayidle/config"
+SWAYIDLE_HOME_CONFIG2="$HOME/swayidle/config"
+
+################################################################
+
+# Kill any previous swayidle
+pkill -f "swayidle -w"
+
+if [ -f "$SWAYIDLE_HOME_CONFIG" ]; then
+    swayidle -w -C "$SWAYIDLE_HOME_CONFIG"
+    exit 0
+fi
+if [ -f "$SWAYIDLE_HOME_CONFIG2" ]; then
+    swayidle -w -C "$SWAYIDLE_HOME_CONFIG2"
+    exit 0
+fi
+exit 1

--- a/helpers/swaync.sh
+++ b/helpers/swaync.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Load the user's home SwayNotificationCenter configuration, if found.
+# Otherwise default to the openSUSEway configuration.
+
+SWAYNC_HOME_CONFIG="$HOME/.config/swaync/config.json"
+SWAYNC_HOME_STYLE="$HOME/.config/swaync/style.css"
+
+SWAYNC_OPENSUSEWAY_CONFIG="/etc/sway/swaync/config.json"
+SWAYNC_OPENSUSEWAY_STYLE="/etc/sway/swaync/style.css"
+
+if [ -f "$SWAYNC_HOME_CONFIG" ]; then
+    if [ -f "$SWAYNC_HOME_STYLE" ]; then
+        swaync --config "$SWAYNC_HOME_CONFIG" --style "$SWAYNC_HOME_STYLE"
+    else
+        swaync --config "$SWAYNC_HOME_CONFIG" --style "$SWAYNC_OPENSUSEWAY_STYLE"
+    fi
+else
+    if [ -f "$SWAYNC_HOME_STYLE" ]; then
+        swaync --config "$SWAYNC_OPENSUSEWAY_CONFIG" --style "$SWAYNC_HOME_STYLE"
+    else
+        swaync --config "$SWAYNC_OPENSUSEWAY_CONFIG" --style "$SWAYNC_OPENSUSEWAY_STYLE"
+    fi
+fi

--- a/helpers/wob.sh
+++ b/helpers/wob.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Load the user's home wob configuration, if found.
+# Otherwise default to the openSUSEway configuration.
+
+set -uo pipefail
+
+WOB_FIFO="$SWAYSOCK.wob"
+WOB_HOME_CONFIG="$HOME/.config/wob/wob.ini"
+WOB_OPENSUSEWAY_CONFIG="/etc/sway/wob/wob.ini"
+
+################################################################
+
+# Kill any previous wob listener
+pkill -f "tail -f $WOB_FIFO"
+
+# Create the wob fifo if not found
+test -e "$WOB_FIFO" || mkfifo "$WOB_FIFO"
+
+if [ -f "$WOB_HOME_CONFIG" ]; then
+    tail -f "$WOB_FIFO" | wob --config "$WOB_HOME_CONFIG"
+else
+    tail -f "$WOB_FIFO" | wob --config "$WOB_OPENSUSEWAY_CONFIG"
+fi

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -211,6 +211,8 @@ install -D -p -m 644 sway/sway.service %{buildroot}%{_prefix}/lib/systemd/user/s
 install -D -p -m 644 sway/sway.desktop %{buildroot}%{_datadir}/wayland-sessions/sway.desktop.brand
 install -D -p -m 755 sway/sway-run.sh %{buildroot}%{_bindir}/sway-run.sh
 
+install -D -p -m 755 helpers/swaync.sh %{buildroot}%{_datadir}/openSUSEway/helpers/swaync.sh
+
 ### alacritty
 # so far doesn't have special branding package and it doesn't support system wide config
 install -D -p -m 644 .config/alacritty/alacritty.toml %{buildroot}%{_sysconfdir}/alacritty/alacritty.toml
@@ -283,6 +285,7 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %{_prefix}/lib/systemd/user/sway.service
 %{_datadir}/wayland-sessions/sway.desktop.brand
 %{_bindir}/sway-run.sh
+%{_datadir}/openSUSEway/helpers/swaync.sh
 
 %dir %{_sysconfdir}/alacritty
 %config(noreplace) %{_sysconfdir}/alacritty/alacritty.toml

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -264,6 +264,8 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %files
 %dir %{_sysconfdir}/xdg/qt5ct/
 %config(noreplace) %{_sysconfdir}/xdg/qt5ct/qt5ct.conf
+%dir %{_datadir}/openSUSEway/
+%dir %{_datadir}/openSUSEway/helpers/
 
 %files -n greetd-branding-openSUSE
 %dir %{_sysconfdir}/greetd/

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -212,6 +212,7 @@ install -D -p -m 644 sway/sway.desktop %{buildroot}%{_datadir}/wayland-sessions/
 install -D -p -m 755 sway/sway-run.sh %{buildroot}%{_bindir}/sway-run.sh
 
 install -D -p -m 755 helpers/swaync.sh %{buildroot}%{_datadir}/openSUSEway/helpers/swaync.sh
+install -D -p -m 755 helpers/wob.sh %{buildroot}%{_datadir}/openSUSEway/helpers/wob.sh
 
 ### alacritty
 # so far doesn't have special branding package and it doesn't support system wide config
@@ -286,6 +287,7 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %{_datadir}/wayland-sessions/sway.desktop.brand
 %{_bindir}/sway-run.sh
 %{_datadir}/openSUSEway/helpers/swaync.sh
+%{_datadir}/openSUSEway/helpers/wob.sh
 
 %dir %{_sysconfdir}/alacritty
 %config(noreplace) %{_sysconfdir}/alacritty/alacritty.toml

--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -211,6 +211,7 @@ install -D -p -m 644 sway/sway.service %{buildroot}%{_prefix}/lib/systemd/user/s
 install -D -p -m 644 sway/sway.desktop %{buildroot}%{_datadir}/wayland-sessions/sway.desktop.brand
 install -D -p -m 755 sway/sway-run.sh %{buildroot}%{_bindir}/sway-run.sh
 
+install -D -p -m 755 helpers/swayidle.sh %{buildroot}%{_datadir}/openSUSEway/helpers/swayidle.sh
 install -D -p -m 755 helpers/swaync.sh %{buildroot}%{_datadir}/openSUSEway/helpers/swaync.sh
 install -D -p -m 755 helpers/wob.sh %{buildroot}%{_datadir}/openSUSEway/helpers/wob.sh
 
@@ -286,6 +287,7 @@ test -e %{_datadir}/wayland-sessions/sway.desktop.orig && \
 %{_prefix}/lib/systemd/user/sway.service
 %{_datadir}/wayland-sessions/sway.desktop.brand
 %{_bindir}/sway-run.sh
+%{_datadir}/openSUSEway/helpers/swayidle.sh
 %{_datadir}/openSUSEway/helpers/swaync.sh
 %{_datadir}/openSUSEway/helpers/wob.sh
 


### PR DESCRIPTION
This fixes one of our longest-standing issues, namely that the user cannot override the configuration of utilities launched in `exec_always` blocks in our sway configuration file.

This introduces an indirection layer in the form of a shell script, which detects if the user home contains configuration for utilities started with `exec_always`, and loads it.

Some past discussion for this in #49 