### PR TITLE
Change Source to tarball obtained with obs_scm

### DIFF
--- a/openSUSEway.spec
+++ b/openSUSEway.spec
@@ -26,7 +26,7 @@ Summary:        The openSUSEway desktop environment meta package
 License:        MIT
 Group:          Metapackages
 URL:            https://github.com/openSUSE/openSUSEway
-Source0:        https://github.com/openSUSE/openSUSEway/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Source1:        openSUSEway.rpmlintrc
 
 BuildArch:      noarch


### PR DESCRIPTION
The tarball is obtained with the `obs_scm` service for convenience (easier to fetch contents of git tags as well as test branches). This `Source` line would overwrite the `obs_scm` tarball with a release tarball downloaded with the implicit `download_files` service, thus losing the ability to handle test branches.